### PR TITLE
Add support for Windows and recursive file search in keymaps

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -7,7 +7,6 @@ subs = new CompositeDisposable
 configDirPath = atom.configDirPath
 keymaps = resolve configDirPath, 'keymaps'
 
-
 #-------------------------------------------------------------------------------
 activate = ->
   loadAllKeymaps = (rootPath) ->
@@ -24,8 +23,7 @@ activate = ->
 
       fullPaths
         .filter valid
-        .map (keymap) ->
-          atom.keymaps.loadKeymap keymap
+        .map loadKeymap
 
   loadAllKeymaps keymaps
 
@@ -34,6 +32,15 @@ validDir = (fullPath) ->
   stats = statSync fullPath
   gitDir = ///.*\.git$///.test fullPath
   return stats.isDirectory() and not gitDir
+
+loadKeymap = (keymap) ->
+  try
+    atom.keymaps.loadKeymap keymap
+  catch error
+    tempOptions =
+      dismissable: false
+      detail: error.stack
+    atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -43,11 +43,14 @@ loadKeymap = (keymap) ->
       watch: true
     atom.keymaps.loadKeymap keymap, options
   catch error
-    tempOptions =
-      dismissable: false
-      detail: error.stack
-    atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
-    atom.keymaps.watchKeymap keymap
+    displayError keymap, error
+
+displayError = (keymap, error) ->
+  tempOptions =
+    dismissable: false
+    detail: error.stack
+  atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
+  atom.keymaps.watchKeymap keymap
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -44,13 +44,13 @@ loadKeymap = (keymap) ->
     atom.keymaps.loadKeymap keymap, options
   catch error
     displayError keymap, error
+    atom.keymaps.watchKeymap keymap
 
 displayError = (keymap, error) ->
   tempOptions =
     dismissable: false
     detail: error.stack
   atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
-  atom.keymaps.watchKeymap keymap
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -33,15 +33,12 @@ activate = ->
 
 #-------------------------------------------------------------------------------
 
-tempkeymaps = keymaps
-if sep is '\\'
-  tempkeymaps = keymaps + '\\'
-  tempkeymaps = tempkeymaps.split('\\').join('\\\\')
-else
-  tempkeymaps = keymaps + '/'
-validregex = ///#{tempkeymaps}.*\.[cj]son$///
+valid = (file) ->
+  tempkeymaps = keymaps + sep
+  if sep is '\\'
+    tempkeymaps = tempkeymaps.split('\\').join('\\\\')
 
-valid = (file) -> validregex.test file
+  ///#{tempkeymaps}.*\.[cj]son$///.test file
 
 open = (keymaps) -> atom.open pathsToOpen: keymaps #, newWindow: true
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,11 +1,11 @@
 {CompositeDisposable} = require 'atom'
 subs = new CompositeDisposable
 {readdir} = require 'fs'
-path = require 'path'
+{sep, resolve} = require 'path'
 {exec} = require 'child_process'
 
 configDirPath = atom.configDirPath
-keymaps = path.resolve configDirPath, 'keymaps'
+keymaps = resolve configDirPath, 'keymaps'
 
 
 #-------------------------------------------------------------------------------
@@ -15,7 +15,7 @@ activate = ->
     throw err if err
 
     out = files
-      .map (fpath) -> path.resolve keymaps, fpath
+      .map (fpath) -> resolve keymaps, fpath
       .filter valid
       .map (keymap) -> atom.keymaps.loadKeymap(keymap)
 #-------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ activate = ->
 #-------------------------------------------------------------------------------
 
 tempkeymaps = keymaps
-if path.sep is '\\'
+if sep is '\\'
   tempkeymaps = keymaps + '\\'
   tempkeymaps = tempkeymaps.split('\\').join('\\\\')
 else


### PR DESCRIPTION
- Add support for Windows
 - Changed the regex with path.sep
- Add recursive file search in keymaps
 - Recursively load valid directories
 - I use github to sync my keymaps, so I excluded .git from the recursive search.
- Add error handling for keymaps
 - Error message shows up if you start with an invalid keymap, improvement from silently failing
 - Incomplete since the filename is incorrect when a keymap file is saved. I attempted to use atom.keymaps.onFileFailedToLoad, but this ended up showing the error message several times.