### PR TITLE
Windows support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,15 +1,17 @@
 {CompositeDisposable} = require 'atom'
 subs = new CompositeDisposable
-{readdir} = require 'fs'
-{resolve} = require 'path'
+fs = require 'fs'
+{sep, resolve} = require 'path'
 {exec} = require 'child_process'
 
-keymaps = "#{atom.configDirPath}/keymaps" # folder
+keymaps = resolve atom.configDirPath, 'keymaps'
 
 #-------------------------------------------------------------------------------
 activate = ->
+  fs.mkdirSync keymaps if !fs.existsSync keymaps
+
   # Load keymaps
-  readdir keymaps, (err, files) ->
+  fs.readdir keymaps, (err, files) ->
     throw err if err
     files
       .map (path) -> resolve keymaps, path
@@ -26,11 +28,14 @@ activate = ->
 
   subs.add atom.commands.add 'atom-workspace',
     'modular-keymaps:open': ->
-      open [ keymaps,"#{atom.configDirPath}/keymap.cson"]
+      open [ keymaps, resolve atom.configDirPath, keymap.cson ]
 
 #-------------------------------------------------------------------------------
 
-valid = (file) -> ///#{keymaps}/.*\.[cj]son$///.test file
+valid = (file) ->
+  tempkeymaps = "#{keymaps}#{sep}"
+  tempkeymaps = tempkeymaps.split('\\').join('\\\\') if sep is '\\'
+  ///#{tempkeymaps}.*\.[cj]son$///.test file
 
 open = (keymaps) -> atom.open pathsToOpen: keymaps #, newWindow: true
 

--- a/index.coffee
+++ b/index.coffee
@@ -7,7 +7,6 @@ subs = new CompositeDisposable
 configDirPath = atom.configDirPath
 keymaps = resolve configDirPath, 'keymaps'
 
-
 #-------------------------------------------------------------------------------
 activate = ->
   loadAllKeymaps = (rootPath) ->
@@ -24,8 +23,7 @@ activate = ->
 
       fullPaths
         .filter valid
-        .map (keymap) ->
-          atom.keymaps.loadKeymap keymap
+        .map loadKeymap
 
   loadAllKeymaps keymaps
 
@@ -34,6 +32,15 @@ validDir = (fullPath) ->
   stats = statSync fullPath
   gitDir = ///.*\.git$///.test fullPath
   return stats.isDirectory() and not gitDir
+
+loadKeymap = (keymap) ->
+  try
+    atom.keymaps.loadKeymap keymap
+  catch error
+    tempOptions =
+      dismissable: false
+      detail: error.stack
+    atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -43,11 +43,14 @@ loadKeymap = (keymap) ->
       watch: true
     atom.keymaps.loadKeymap keymap, options
   catch error
-    tempOptions =
-      dismissable: false
-      detail: error.stack
-    atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
-    atom.keymaps.watchKeymap keymap
+    displayError keymap, error
+
+displayError = (keymap, error) ->
+  tempOptions =
+    dismissable: false
+    detail: error.stack
+  atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
+  atom.keymaps.watchKeymap keymap
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -44,13 +44,13 @@ loadKeymap = (keymap) ->
     atom.keymaps.loadKeymap keymap, options
   catch error
     displayError keymap, error
+    atom.keymaps.watchKeymap keymap
 
 displayError = (keymap, error) ->
   tempOptions =
     dismissable: false
     detail: error.stack
   atom.notifications.addError 'Failed to load `' + keymap + '`', tempOptions
-  atom.keymaps.watchKeymap keymap
 
 #-------------------------------------------------------------------------------
 

--- a/index.coffee
+++ b/index.coffee
@@ -33,15 +33,12 @@ activate = ->
 
 #-------------------------------------------------------------------------------
 
-tempkeymaps = keymaps
-if sep is '\\'
-  tempkeymaps = keymaps + '\\'
-  tempkeymaps = tempkeymaps.split('\\').join('\\\\')
-else
-  tempkeymaps = keymaps + '/'
-validregex = ///#{tempkeymaps}.*\.[cj]son$///
+valid = (file) ->
+  tempkeymaps = keymaps + sep
+  if sep is '\\'
+    tempkeymaps = tempkeymaps.split('\\').join('\\\\')
 
-valid = (file) -> validregex.test file
+  ///#{tempkeymaps}.*\.[cj]son$///.test file
 
 open = (keymaps) -> atom.open pathsToOpen: keymaps #, newWindow: true
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,11 +1,11 @@
 {CompositeDisposable} = require 'atom'
 subs = new CompositeDisposable
 {readdir} = require 'fs'
-path = require 'path'
+{sep, resolve} = require 'path'
 {exec} = require 'child_process'
 
 configDirPath = atom.configDirPath
-keymaps = path.resolve configDirPath, 'keymaps'
+keymaps = resolve configDirPath, 'keymaps'
 
 
 #-------------------------------------------------------------------------------
@@ -15,7 +15,7 @@ activate = ->
     throw err if err
 
     out = files
-      .map (fpath) -> path.resolve keymaps, fpath
+      .map (fpath) -> resolve keymaps, fpath
       .filter valid
       .map (keymap) -> atom.keymaps.loadKeymap(keymap)
 #-------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ activate = ->
 #-------------------------------------------------------------------------------
 
 tempkeymaps = keymaps
-if path.sep is '\\'
+if sep is '\\'
   tempkeymaps = keymaps + '\\'
   tempkeymaps = tempkeymaps.split('\\').join('\\\\')
 else


### PR DESCRIPTION
(Commit Message)

On Windows, installation failed due to postinstall script and activation failed due to incorrect seperator handling. I was unable to figure out an os agnostic way to handle the postinstall script so I moved it to activation.
