### PR TITLE
Add Windows Support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,15 +1,17 @@
 {CompositeDisposable} = require 'atom'
 subs = new CompositeDisposable
-{readdir} = require 'fs'
-{resolve} = require 'path'
+fs = require 'fs'
+{sep, resolve} = require 'path'
 {exec} = require 'child_process'
 
-keymaps = "#{atom.configDirPath}/keymaps" # folder
+keymaps = resolve atom.configDirPath, 'keymaps' # folder
 
 #-------------------------------------------------------------------------------
 activate = ->
+  fs.mkdirSync keymaps if !fs.existsSync keymaps
+
   # Load keymaps
-  readdir keymaps, (err, files) ->
+  fs.readdir keymaps, (err, files) ->
     throw err if err
     files
       .map (path) -> resolve keymaps, path
@@ -26,11 +28,14 @@ activate = ->
 
   subs.add atom.commands.add 'atom-workspace',
     'modular-keymaps:open': ->
-      open [ keymaps,"#{atom.configDirPath}/keymap.cson"]
+      open [ keymaps, resolve atom.configDirPath, keymap.cson ]
 
 #-------------------------------------------------------------------------------
 
-valid = (file) -> ///#{keymaps}/.*\.[cj]son$///.test file
+valid = (file) ->
+  tempkeymaps = "#{keymaps}#{sep}"
+  tempkeymaps = tempkeymaps.split('\\').join('\\\\') if sep is '\\'
+  ///#{tempkeymaps}.*\.[cj]son$///.test file
 
 open = (keymaps) -> atom.open pathsToOpen: keymaps #, newWindow: true
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   },
   "private": true,
   "license": "MIT",
-  "scripts": {
-    "postinstall": "mkdir -p \"${ATOM_HOME:-~/.atom}\"/keymaps"
-  },
   "engines": {
     "atom": "*"
   }


### PR DESCRIPTION
On Windows, installation failed due to postinstall script and activation failed due to incorrect seperator handling. I was unable to figure out an os agnostic way to handle the postinstall script so I moved it to
activation.